### PR TITLE
Add CI for RSpec.

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,24 @@
+
+name: RSpec
+
+on:
+  pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+
+    - name: Run tests
+      run: bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   dead_end


### PR DESCRIPTION
The repository does not have CI, so we do not test codes in GitHub.
We do not know whether tests are passed or not.
So, we want CI to execute RSpec and RuboCop to test codes.

First, we add RSpec workflow.
And, we need to add another platform in Gemfile.lock to execute RSpec workflow.
So that, we add x86-64-linux to PLATFORMS section in Gemfile.lock.

We will add Rubocop workflow in another Pull Request.