### PR TITLE
Add CI for RuboCop

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,27 @@
+
+name: Rubocop
+
+on:
+  pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+
+    - name: rubocop
+      uses: reviewdog/action-rubocop@v2
+      with:
+        rubocop_version: gemfile
+        reporter: github-pr-review

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-rspec
+
 AllCops:
   NewCops: enable
   Exclude:


### PR DESCRIPTION
The repository does not have RuboCop CI, so we do not detect bad codes GitHub.
So, we want CI to execute RuboCop to test codes.
Ref: https://github.com/M-Yamashita01/esgil/pull/1