### PR TITLE
Enabled short arguments when we use esgil gem.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,6 @@ Style/AccessorGrouping:
 
 Style/NegatedIf:
   Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false

--- a/lib/esgil/options.rb
+++ b/lib/esgil/options.rb
@@ -33,9 +33,9 @@ module Esgil
         @options = {}
 
         option_parser = OptionParser.new
-        option_parser.on('--from FROM_BRANCH') { |v| @options[:from_branch] = v }
-        option_parser.on('--to FROM_BRANCH') { |v| @options[:to_branch] = v }
-        option_parser.on('--message MESSAGE') { |v| @options[:message] = v }
+        option_parser.on('--from FROM_BRANCH', '-f') { |v| @options[:from_branch] = v }
+        option_parser.on('--to FROM_BRANCH', '-t') { |v| @options[:to_branch] = v }
+        option_parser.on('--message MESSAGE', '-m') { |v| @options[:message] = v }
       end
 
       def all_options_exist?

--- a/spec/esgil/options_spec.rb
+++ b/spec/esgil/options_spec.rb
@@ -4,13 +4,13 @@ require_relative '../../lib/esgil/options'
 
 RSpec.describe Esgil::Options do
   describe '.parse' do
-    subject { described_class.parse(command_line_args: command_line_args)}
+    subject(:parse_command_line_args) { described_class.parse(command_line_args: command_line_args)}
 
     context 'when all arguments exist' do
       let(:command_line_args) { ['--from', 'from_test', '--to', 'to_test', '--message', 'test_message'] }
 
       it 'gets instance variable in Esgil::Option class' do
-        options = subject
+        options = parse_command_line_args
         expect(options.from_branch).to eq('from_test')
         expect(options.to_branch).to eq('to_test')
         expect(options.message).to eq('test_message')
@@ -21,7 +21,7 @@ RSpec.describe Esgil::Options do
       let(:command_line_args) { ['-f', 'from_test', '-t', 'to_test', '-m', 'test_message'] }
 
       it 'gets instance variable in Esgil::Option class' do
-        options = subject
+        options = parse_command_line_args
         expect(options.from_branch).to eq('from_test')
         expect(options.to_branch).to eq('to_test')
         expect(options.message).to eq('test_message')
@@ -32,7 +32,7 @@ RSpec.describe Esgil::Options do
       let(:command_line_args) { ['--from', 'from_test', '--to', 'to_test'] }
 
       it 'gets ArgumentsError exception' do
-        expect { subject }.to raise_error(ArgumentError)
+        expect { parse_command_line_args }.to raise_error(ArgumentError)
       end
     end
 
@@ -40,7 +40,7 @@ RSpec.describe Esgil::Options do
       let(:command_line_args) { ['--test'] }
 
       it 'gets OptionParser::InvalidOption exception' do
-        expect { subject }.to raise_error(OptionParser::InvalidOption)
+        expect { parse_command_line_args }.to raise_error(OptionParser::InvalidOption)
       end
     end
 
@@ -48,7 +48,7 @@ RSpec.describe Esgil::Options do
       let(:command_line_args) { ['--from', 'from_test', '--to', 'to_test', '--message', 'test_message', 'sample'] }
 
       it 'gets ArgumentsError exception' do
-        expect { subject }.to raise_error(ArgumentError)
+        expect { parse_command_line_args }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/esgil/options_spec.rb
+++ b/spec/esgil/options_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe Esgil::Options do
       end
     end
 
+    context 'when short arguments exist' do
+      let(:command_line_args) { ['-f', 'from_test', '-t', 'to_test', '-m', 'test_message'] }
+
+      it 'gets instance variable in Esgil::Option class' do
+        options = subject
+        expect(options.from_branch).to eq('from_test')
+        expect(options.to_branch).to eq('to_test')
+        expect(options.message).to eq('test_message')
+      end
+    end
+
     context 'when some arguments exist' do
       let(:command_line_args) { ['--from', 'from_test', '--to', 'to_test'] }
 


### PR DESCRIPTION
We can use short arguments (ex. -f, -t, -m) when we use esgil gem.

Esgil gem had accepted long arguments only (ex. --from, --to, --message), so we can use short arguments.